### PR TITLE
Changing the windows app to point to release

### DIFF
--- a/pxtwapp/pxtwapp/package.appxmanifest
+++ b/pxtwapp/pxtwapp/package.appxmanifest
@@ -14,7 +14,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="App" StartPage="https://makecode.adafruit.com/beta">
+    <Application Id="App" StartPage="https://makecode.adafruit.com">
       <uap:ApplicationContentUriRules>
         <uap:Rule Match="https://makecode.adafruit.com" Type="include" WindowsRuntimeAccess="all" />
         <uap:Rule Match="https://trg-adafruit.userpxt.io/---simulator" Type="include" WindowsRuntimeAccess="none" />


### PR DESCRIPTION
Looks like we didn't move the appmanifest to point to release. Fixing the same. 