### PR TITLE
[Accessibility] High contrast mode enabled and fixed

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -280,6 +280,7 @@
         "usbHelp": [],
         "extendEditor": true,
         "disableBlockIcons": true,
+        "highContrast": true,
         "socialOptions": {
             "twitterHandle": "adafruit",
             "orgTwitterHandle": "MSMakeCode",

--- a/theme/style.less
+++ b/theme/style.less
@@ -50,6 +50,29 @@
     -webkit-box-shadow: 0 0 1px rgba(0, 0, 0, 0.8);
 }
 
+/* High contrast */
+.hc {
+    #downloadArea {
+        background: transparent !important;
+    }
+
+    .ui.inverted.input input,
+    .ui.projectname-input.input input {
+        border: black 1px solid !important;
+        color: black !important;
+        background-color: white !important
+    }
+
+    #menubar .ui.menu.fixed .ui.item.editor-menuitem .item:not(.active) {
+        opacity: 1;
+    }
+
+    #menubar .ui.menu.inverted.fixed .ui.item.editor-menuitem .active.item,
+    #menubar .ui.menu.projectname-input.fixed .ui.item.editor-menuitem .active.item {
+        color: white !important;
+    }
+} 
+
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
     #filelist {


### PR DESCRIPTION
Enabled the High Contrast menu and fixed the high contrast color mode.

Result : 
![1](https://user-images.githubusercontent.com/3747805/29390508-b0d3245a-82a5-11e7-8e10-cea2cbd2ee60.PNG)

![2](https://user-images.githubusercontent.com/3747805/29390509-b0d36ce4-82a5-11e7-9c4b-488bc3216d0d.PNG)

To use/test/merge this PR, we will need the changes from the following PR from PXT-core : [https://github.com/Microsoft/pxt/pull/2736](https://github.com/Microsoft/pxt/pull/2736). This means that before, we also need to do a cherry-pick of v0/accessibility to master in PXT.
Without it, the current PR will build but might not render correctly.
