### PR TITLE
[Accessibility] Fixed the color contrast issue in the documentation

### DIFF
--- a/theme/theme.config
+++ b/theme/theme.config
@@ -43,7 +43,7 @@
 @form       : 'default';
 @grid       : 'pxt';
 @menu       : 'pxt';
-@message    : 'default';
+@message    : 'pxt';
 @table      : 'default';
 
 /* Modules */


### PR DESCRIPTION
Fixed an issue where the color contrast of the green text in the documentation was not correct.

This PR is a copy of [https://github.com/Microsoft/pxt-adafruit/pull/323](https://github.com/Microsoft/pxt-adafruit/pull/323) but for the Master branch.

Related issue : [https://github.com/Microsoft/pxt/issues/2528](https://github.com/Microsoft/pxt/issues/2528)
Related PR : [https://github.com/Microsoft/pxt/pull/2928](https://github.com/Microsoft/pxt/pull/2928)

For some reason, this issue was fixed by the past but has been reverted at a moment. I think it's when we moved some changes to PXT instead of PXT-adafruit.

![untitled](https://user-images.githubusercontent.com/3747805/30338623-1b3ca55e-97a1-11e7-9458-dddea8f656f0.png)
