### PR TITLE
[Accessibility] Updated the simulator to support accessibility feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "pxt-common-packages": "0.9.5",
-    "pxt-core": "2.0.42"
+    "pxt-core": "2.0.49"
   },
   "scripts": {
     "test": "node node_modules/pxt-core/built/pxt.js travis"

--- a/sim/visuals/board.ts
+++ b/sim/visuals/board.ts
@@ -74,11 +74,11 @@ namespace pxsim.visuals {
         }
 
         .sim-text {
-        font-family:"Lucida Console", Monaco, monospace;
-        font-size:8px;
-        fill:#fff;
-        pointer-events: none; user-select: none;
-    }
+            font-family:"Lucida Console", Monaco, monospace;
+            font-size:8px;
+            fill:#fff;
+            pointer-events: none; user-select: none;
+        }
         .sim-text.small {
             font-size:6px;
         }
@@ -87,10 +87,10 @@ namespace pxsim.visuals {
         }
 
         .sim-text-pin {
-        font-family:"Lucida Console", Monaco, monospace;
-        font-size:5px;
-        fill:#fff;
-        pointer-events: none;
+            font-family:"Lucida Console", Monaco, monospace;
+            font-size:5px;
+            fill:#fff;
+            pointer-events: none;
         }
 
         .sim-thermometer {
@@ -184,6 +184,19 @@ namespace pxsim.visuals {
         .sim-wireframe .sim-board {
             stroke-width: 2px;
         }
+        *:focus {
+            outline: none;
+        }
+        .sim-button-outer:focus,
+        .sim-slide-switch:focus,
+        .sim-pin:focus,
+        .sim-thermometer:focus,
+        .sim-button-group:focus .sim-button-outer,
+        .sim-light-level-button:focus,
+        .sim-sound-level-button:focus {
+            stroke: #4D90FE;
+            stroke-width: 2px !important;
+         }
         .no-drag {
             user-drag: none;
             user-select: none;

--- a/sim/visuals/board.ts
+++ b/sim/visuals/board.ts
@@ -493,7 +493,7 @@ namespace pxsim.visuals {
 
                 accessibility.enableKeyboardInteraction(this.slideSwitch, null, () => this.slideSwitchHandler());
                 accessibility.makeFocusable(this.slideSwitch);
-                this.updateSwitchAria();
+                this.renderSwitchAria();
 
                 this.element.getElementById(`SLIDE_HOUSING`).addEventListener(pointerEvents.up, ev => this.slideSwitchHandler())
                 this.element.getElementById(`SLIDE_INNER`).addEventListener(pointerEvents.up, ev => this.slideSwitchHandler())
@@ -515,10 +515,10 @@ namespace pxsim.visuals {
                 switchSlide.removeAttribute("transform");
             }
 
-            this.updateSwitchAria();
+            this.renderSwitchAria();
         }
 
-        private updateSwitchAria() {
+        private renderSwitchAria() {
             let status = this.board.slideSwitchState.isLeft() ? "On" : "Off";
             accessibility.setAria(this.slideSwitch, "button", "On/Off Switch. Current state : " + status);
             this.slideSwitch.setAttribute("aria-pressed", this.board.slideSwitchState.isLeft().toString());

--- a/sim/visuals/pincontrol.ts
+++ b/sim/visuals/pincontrol.ts
@@ -15,6 +15,10 @@ namespace pxsim.visuals {
             svg.addClass(this.outerElement, "sim-pin-touch");
             this.addButtonEvents();
 
+            if ((this.pin as pins.CommonPin).used) {
+                accessibility.makeFocusable(this.outerElement);
+                accessibility.setAria(this.outerElement, "button", this.outerElement.firstChild.textContent);
+            }
 
             // Init the gradient controls
             // const gid = `gradient-${CPlayPinName[id]}-level`;
@@ -68,6 +72,20 @@ namespace pxsim.visuals {
 
                 (pxtcore.getTouchButton(this.id - 1) as CommonButton).setPressed(false);
             })
+            accessibility.enableKeyboardInteraction(this.outerElement, 
+                () => {
+                    this.pin.touched = true;
+                    svg.addClass(this.outerElement, "touched");
+
+                    (pxtcore.getTouchButton(this.id - 1) as CommonButton).setPressed(true);
+                },
+                () => {
+                    this.pin.touched = false;
+                    svg.removeClass(this.outerElement, "touched");
+
+                    (pxtcore.getTouchButton(this.id - 1) as CommonButton).setPressed(false);
+                }
+            );
         }
 
         private addLevelControlEvents() {


### PR DESCRIPTION
Added the support of the keyboard navigation and screen reader to the Adafruit simulator.

This PR is a copy of [https://github.com/Microsoft/pxt-adafruit/pull/287](https://github.com/Microsoft/pxt-adafruit/pull/287) but for Master.

Here is a footage of the simulator when interactive elements have the focus : 
![capture](https://user-images.githubusercontent.com/3747805/30177072-6f9e4558-93b9-11e7-9491-8ed7b6b7f670.PNG)

## Important

This PR also need the following PR from PXT-Core to build : [https://github.com/Microsoft/pxt/pull/2888](https://github.com/Microsoft/pxt/pull/2888)