### PR TITLE
Serial chart color theming

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -26,8 +26,8 @@
         "useEditor": true,
         "log": true,
         "editorTheme": {
-            "backgroundColor": "#d9d9d9",
-            "serialDark": "#676767"
+            "graphBackground": "#d9d9d9",
+            "lineColors": ["#CC2936", "#FFC914", "#2EB7ED", "#FB48C7", "#08415C", "#C200C0"]
         }
     },
     "simulator": {
@@ -311,6 +311,6 @@
             "functions": "#005a9e",
             "arrays": "#8A1C7C"
         },
-        "allowPackageExtensions": true        
+        "allowPackageExtensions": true
     }
 }

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -95,4 +95,3 @@
 
 @serialTextColor: white;
 @serialGraphBackground: #d9d9d9;
-@serialDark: #676767;


### PR DESCRIPTION
Serial charts use target colors if provided - if not, default to basic #f00, #0f0, #00f, #ff0.

![screen shot 2017-10-06 at 11 05 44 am](https://user-images.githubusercontent.com/16658549/31291865-1897d222-aa86-11e7-9e2b-8dadf2b34c89.png)
![screen shot 2017-10-06 at 11 05 33 am](https://user-images.githubusercontent.com/16658549/31291870-1a58c8dc-aa86-11e7-8532-b0ef8b85291c.png)
![screen shot 2017-10-06 at 11 05 22 am](https://user-images.githubusercontent.com/16658549/31291873-1bed5c94-aa86-11e7-8c14-5b4838546393.png)
