### PR TITLE
Remove examples from help dropdown. No longer supported

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -251,10 +251,6 @@
                 "path": "/tutorials/getting-started"
             },
             {
-                "name": "Examples",
-                "path": "#projects:Examples"
-            },
-            {
                 "name": "Blocks",
                 "path": "/blocks"
             },


### PR DESCRIPTION
Fixes #353