### PR TITLE
Define 'driveDisplayName' for @drivename@ macro

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -265,6 +265,7 @@
         "betaUrl": "https://www.research.net/r/MCcplay",
         "crowdinProject": "kindscript",
         "boardName": "Adafruit Circuit Playground Express",
+        "driveDisplayName": "CPLAYBOOT",
         "docMenu": [{
                 "name": "About",
                 "path": "/about"


### PR DESCRIPTION
Fixes #286: "unknown macro" for ``@drivename@``.