### PR TITLE
Hide SVG drag filter

### DIFF
--- a/theme/blockly.less
+++ b/theme/blockly.less
@@ -73,3 +73,8 @@ span.blocklyTreeLabel {
         padding: 0.2rem;
     }
 }
+
+/* SVG filters fail intermittently in IE / Edge. Removing SVG filters until we figure out the issue */
+svg.blocklyBlockDragSurface > g {
+    filter: none;
+}


### PR DESCRIPTION
Hide SVG drag filter until we figure out the disappearing issue with IE / Edge 13
