### PR TITLE
Restructure reference summary

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,13 +34,53 @@
 ## Reference #reference
 
 * [Reference](/reference)
-    * [input](/reference/input)
-    * [light](/reference/light)
-    * [music](/reference/music)
-    * [network](/reference/network)
-    * [pins](/reference/pins)
-    * [control](/reference/control)
-    * [serial](/reference/serial)
+    * [Essentials](/blocks)
+        * [On Start](/blocks/on-start)
+        * [Loops](/blocks/loops)
+            * [repeat](/blocks/loops/repeat)
+            * [for](/blocks/loops/for)
+            * [while](/blocks/loops/while)
+        * [Logic](/blocks/logic)
+            * [if](/blocks/logic/if)
+            * [Boolean](/blocks/logic/boolean)
+        * [Variables](/blocks/variables)
+            * [assign](/blocks/variables/assign)
+            * [change var](/blocks/variables/change)
+            * [var](/blocks/variables/var)
+        * [Math](/blocks/math)
+        * [JavaScript blocks](/blocks/javascript-blocks)
+        * [Custom blocks](/blocks/custom)
+    * [Types](/types)
+        * [Number](/types/number)
+        * [String](/types/string)
+        * [Boolean](/types/boolean)
+        * [Array](/types/array)
+        * [Function](/types/function)
+    * [Components](/components)
+        * [input](/reference/input)
+        * [light](/reference/light)
+        * [music](/reference/music)
+        * [network](/reference/network)
+        * [pins](/reference/pins)
+        * [control](/reference/control)
+        * [serial](/reference/serial)
+    * [JavaScript](/javascript)
+        * [Calling](/javascript/call)
+        * [Sequencing](/javascript/sequence)
+        * [Variables](/javascript/variables)
+        * [Operators](/javascript/operators)
+        * [Statements](/javascript/statements)
+        * [Functions](/javascript/functions)
+        * [Types](/javascript/types)
+        * [Classes](/javascript/classes)
+        * [Interfaces](/javascript/interfaces)
+        * [Generics](/javascript/generics)
+
+## #blocks
+
+## #javaScript
+
+## #types
 
 ## Hardware #hardware
 

--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -1,0 +1,4 @@
+# @extends
+
+## #blocksbase
+

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,20 @@
+# Components
+
+```namespaces
+input.onGesture(Gesture.Shake, () => {})
+light.showRing('red red red red red red red red red red')
+music.playTone(0, 0)
+network.infraredSendNumber(0)
+pins.pulseDuration()
+control.runInBackground(() => {})
+serial.writeLine("");
+```
+
+## See Also
+
+[blocks](/blocks), [JavaScript](/javascript), [input](/reference/input), [light](/reference/light), [music](/reference/music), [network](/reference/network),
+[control](/reference/control), [pins](/reference/pins), [serial](/reference/serial)
+
+```package
+circuit-playground
+```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,20 +1,18 @@
-# Reference
+# Blocks reference
 
-```namespaces
-input.onGesture(Gesture.Shake, () => {})
-light.showRing('red red red red red red red red red red')
-music.playTone(0, 0)
-network.infraredSendNumber(0)
-pins.pulseDuration()
-control.runInBackground(() => {})
-serial.writeLine("");
-```
+Blocks snap into each other to define the program that your @boardname@ will run.
+Blocks can be an event (buttons, shake, ...) or need to be snapped into an event to run.
+The [on-start](/blocks/on-start) event runs first.
 
-## See Also
+Blocks have many purposes. Some control the flow of your program, others save and access your data. There are additional blocks which control the features of your @boardname@.
 
-[blocks](/blocks), [JavaScript](/javascript), [input](/reference/input), [light](/reference/light), [music](/reference/music), [network](/reference/network),
-[control](/reference/control), [pins](/reference/pins), [serial](/reference/serial)
+### Blocks language
 
-```package
-circuit-playground
-```
+* **[Essentials](/blocks)**: essential blocks which form a program and access data.
+* **[Types](/types)**: the blocks that represent your data.
+* **[Components](/components)**: the blocks that control the parts on the @boardname@.
+
+## JavaScript programming
+
+* **[JavaScript](/javascript)**: the reference information for programming in JavaScript.
+


### PR DESCRIPTION
This is a proposed reference consolidation:

- [x] Move **Blocks**, **Types**, and **JavaScript** under **Reference**
- [x] Rename **Blocks** ==> **Essentials**, as in "essential blocks" (syn for basic, fundamental, etc.).
- [x] Rename **Reference** ==> **Components** to indicate blocks related to aspects of the board specifically.
- [x] **Types** and **JavaScript** stay the same.

It was discussed that I try something for this by only modifying the summary first. If actual paths and path strings in the block code need to change, then that could happen in addition to just summary changes.

See the caps in https://github.com/Microsoft/pxt/issues/3397 for the look of the left nav.