### PR TITLE
Include the 'About' page in summary

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -47,3 +47,7 @@
 * [Hardware](/device)
     * [Simulator](/device/simulator)
     * [USB](/device/usb)
+
+## About #about
+
+* [About](/about)


### PR DESCRIPTION
Fix for #549.

Put **About** at the end of SUMMARY, beginning of SUMMARY, or not at all?