### PR TITLE
Swap console for serial in reference

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -41,7 +41,7 @@
     * [network](/reference/network)
     * [pins](/reference/pins)
     * [control](/reference/control)
-    * [serial](/reference/serial)
+    * [console](/reference/console)
 
 ## Hardware #hardware
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,13 +7,13 @@ music.playTone(0, 0)
 network.infraredSendNumber(0)
 pins.pulseDuration()
 control.runInBackground(() => {})
-serial.writeLine("");
+console.log("");
 ```
 
 ## See Also
 
 [blocks](/blocks), [JavaScript](/javascript), [input](/reference/input), [light](/reference/light), [music](/reference/music), [network](/reference/network),
-[control](/reference/control), [pins](/reference/pins), [serial](/reference/serial)
+[control](/reference/control), [pins](/reference/pins), [console](/reference/console)
 
 ```package
 circuit-playground

--- a/docs/reference/serial.md
+++ b/docs/reference/serial.md
@@ -1,0 +1,33 @@
+# Serial
+
+Reading and writing data over a serial connection.
+
+## ~hint
+
+The @boardname@ can read data from and write data to another computer or device with a serial connection using USB. To use serial communication between your board and MakeCode, you need the [MakeCode for Adafruit](https://www.microsoft.com/store/apps/9pgzhwsk0pgd) app for Windows 10 and a USB cable.
+
+You can also write data to an output log with the [console](/reference/console) functions without having to use a serial connection.
+
+## ~
+
+```cards
+serial.writeLine("");
+serial.writeNumber(0);
+serial.writeValue("x", 0);
+serial.writeString("");
+```
+
+## Advanced
+
+```cards
+serial.writeBuffer(null);
+```
+
+## See Also
+
+[write line](/reference/serial/write-line),
+[write string](/reference/serial/write-string),
+[write number](/reference/serial/write-number),
+[write value](/reference/serial/write-value),
+[write buffer](/reference/serial/write-buffer),
+[console](/reference/console) 


### PR DESCRIPTION
RE: #672 

- [x] Replace **Serial** with **Console** in SUMMARY
- [x] Replace **Serial** with **Console** in reference namespace cards
- [x] Add a target _serial.md_ and note the usage of the Windows 10 app