### PR TITLE
Use new pin classes to restrict analog pin access

### DIFF
--- a/docs/reference/pins.md
+++ b/docs/reference/pins.md
@@ -2,10 +2,10 @@
 # #pins
 
 ```cards
-pins.A0.digitalRead()
-pins.A0.digitalWrite(false)
-pins.A0.analogRead()
-pins.A0.analogWrite(1023)
+pins.A1.digitalRead()
+pins.A1.digitalWrite(false)
+pins.A1.analogRead()
+pins.A1.analogWrite(1023)
 pins.A1.analogSetPeriod(20000)
 pins.A1.servoWrite(180)
 pins.A1.servoSetPulse(1500)

--- a/libs/circuit-playground/device.d.ts
+++ b/libs/circuit-playground/device.d.ts
@@ -1,7 +1,7 @@
 declare namespace pins {
     // pin-pads
     //% fixedInstance shim=pxt::getPin(PIN_A0)
-    const A0: PwmPin;
+    const A0: AnalogOutPin;
     //% fixedInstance shim=pxt::getPin(PIN_A1)
     const A1: PwmPin;
     //% fixedInstance shim=pxt::getPin(PIN_A2)
@@ -10,13 +10,14 @@ declare namespace pins {
     const A3: PwmPin;
 
     //% fixedInstance shim=pxt::getPin(PIN_A4)
-    const A4: PwmPin;
+    const A4: AnalogInPin;
     //% fixedInstance shim=pxt::getPin(PIN_A5)
-    const A5: PwmPin;
+    const A5: AnalogInPin;
+    
     //% fixedInstance shim=pxt::getPin(PIN_A6)
-    const A6: PwmPin;
+    const A6: AnalogInPin; // could be PwmPin when mbed fixed
     //% fixedInstance shim=pxt::getPin(PIN_A7)
-    const A7: PwmPin;
+    const A7: AnalogInPin; // could be PwmPin when mbed fixed
 
     // Define aliases, as Digital Pins
 
@@ -32,9 +33,9 @@ declare namespace pins {
     // Aliases for built-in components
 
     //% fixedInstance shim=pxt::getPin(PIN_A8)
-    const A8: PwmPin; // light
+    const A8: AnalogInPin; // light
     //% fixedInstance shim=pxt::getPin(PIN_A9)
-    const A9: PwmPin;
+    const A9: AnalogInPin; // temp
     //% fixedInstance shim=pxt::getPin(PIN_D4)
     const D4: DigitalPin; // A
     //% fixedInstance shim=pxt::getPin(PIN_D5)
@@ -48,9 +49,6 @@ declare namespace pins {
     const D13: DigitalPin;
     //% fixedInstance shim=pxt::getPin(PIN_D13)
     const LED: DigitalPin;
-
-    //% fixedInstance shim=pxt::getPin(PIN_A10)
-    const A10: PwmPin; // mic
 }
 
 

--- a/libs/circuit-playground/device.d.ts
+++ b/libs/circuit-playground/device.d.ts
@@ -7,7 +7,7 @@ declare namespace pins {
     //% fixedInstance shim=pxt::getPin(PIN_A2)
     const A2: PwmPin;
     //% fixedInstance shim=pxt::getPin(PIN_A3)
-    const A3: PwmPin;
+    const A3: AnalogInPin;
 
     //% fixedInstance shim=pxt::getPin(PIN_A4)
     const A4: AnalogInPin;

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -19,7 +19,7 @@ declare namespace pins {
 }
 
 
-declare interface AnalogPin {
+declare interface AnalogInPin {
     /**
      * Read the connector value as analog, that is, as a value comprised between 0 and 1023.
      * @param name pin to write to
@@ -30,9 +30,12 @@ declare interface AnalogPin {
     //% parts="photocell" trackArgs=0
     //% name.fieldEditor="gridpicker"
     //% name.fieldOptions.width=220
-    //% name.fieldOptions.columns=4 shim=AnalogPinMethods::analogRead
+    //% name.fieldOptions.columns=4 shim=AnalogInPinMethods::analogRead
     analogRead(): int32;
+}
 
+
+declare interface AnalogOutPin {
     /**
      * Set the connector value as analog. Value must be comprised between 0 and 1023.
      * @param name pin name to write to
@@ -44,7 +47,7 @@ declare interface AnalogPin {
     //% parts="analogled" trackArgs=0
     //% name.fieldEditor="gridpicker"
     //% name.fieldOptions.width=220
-    //% name.fieldOptions.columns=4 shim=AnalogPinMethods::analogWrite
+    //% name.fieldOptions.columns=4 shim=AnalogOutPinMethods::analogWrite
     analogWrite(value: int32): void;
 }
 

--- a/libs/music/shims.d.ts
+++ b/libs/music/shims.d.ts
@@ -8,7 +8,7 @@ declare namespace music {
      * Set a source of digital sound data (PCM) for making tones.
      * Samples are 1024 x 10bit unsigned PCM.
      * A reference to the buffer is kept to avoid the memory overhead, so changes to the buffer
-     * values are reflected immediately to the sound output. 
+     * values are reflected immediately to the sound output.
      */
     //% help=music/set-tone
     //% weight=1 group="Tones"
@@ -30,7 +30,7 @@ declare namespace music {
     /**
      * Play a tone through the speaker for some amount of time.
      * @param frequency pitch of the tone to play in Hertz (Hz), eg: Note.C
-     * @param ms tone duration in milliseconds (ms), eg: music.beat(BeatFraction.Half)
+     * @param ms tone duration in milliseconds (ms), eg: BeatFraction.Half
      */
     //% help=music/play-tone
     //% blockId=music_play_note block="play tone|at %note=device_note|for %duration=device_beat"

--- a/libs/music/shims.d.ts
+++ b/libs/music/shims.d.ts
@@ -1,9 +1,12 @@
 // Auto-generated. Do not edit.
+
+
+declare interface AnalogOutPin {}
 declare namespace music {
 
     /**
      * Set a source of digital sound data (PCM) for making tones.
-     * Samples are 1020 x 10bit unsigned PCM.
+     * Samples are 1024 x 10bit unsigned PCM.
      * A reference to the buffer is kept to avoid the memory overhead, so changes to the buffer
      * values are reflected immediately to the sound output. 
      */

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/node": "8.0.53"
   },
   "dependencies": {
-    "pxt-common-packages": "0.20.31",
+    "pxt-common-packages": "0.20.32",
     "pxt-core": "3.7.1"
   },
   "scripts": {


### PR DESCRIPTION
Depends on https://github.com/Microsoft/pxt-common-packages/pull/268
Test program (needs osciloscope):

```typescript
forever(function () {
    light.showAnimation(light.rainbowAnimation, 500)
})

let v = 300
function setV() {
    pins.A0.analogWrite(v)
    pins.A1.analogWrite(v)
    pins.A2.analogWrite(v)
    pins.A3.analogWrite(v)
}

input.buttonA.onEvent(ButtonEvent.Click, function () {
    v += 300
    v = v % 1000
    setV()
})
```