### PR TITLE
Add note for hue vs. rgb

### DIFF
--- a/docs/reference/light/set-photon-pen-hue.md
+++ b/docs/reference/light/set-photon-pen-hue.md
@@ -6,10 +6,11 @@ Change the color **hue** of the photon on the pixel strip.
 light.setPhotonPenHue(0)
 ```
 
-The photon effect is a pulse of bright light moving through a strip of colored pixels.
-You can change the color of the photon to whatever you want.
+The photon effect is a pulse of bright light moving through a strip of colored pixels. You can change the color of the photon to whatever you want.
 
 The color is a **hue** and not an _RGB_ number. This means that red light is `0` and red light is also `255`. All the other colors are between `0` and `255`. Color begins at red and ends up back at red.
+
+One way to think about hue is that all the color numbers for hue are arranged on a wheel or circle. The values start at red and change to other colors as you go around the wheel. Moving along the outside edge of the wheel, the values increase until you finally reach red again.
 
 ## Parameters
 
@@ -27,6 +28,11 @@ the _hue_ of the color you want.
 > * pink - `234`
 > * red - `255`
 
+## ~hint
+
+The hue value for a color is **not** the same as an RGB color value. Don't use an RGB number or the ``||light:rgb||`` block for **hue**.
+
+## ~
 
 ## Example
 
@@ -47,9 +53,10 @@ forever(function() {
 ```
 ## See also
 
-[``||photon forward||``](/reference/light/photon-forward),
-[``||photon flip||``](/reference/light/photon-flip),
-[``||photon mode||``](/reference/light/set-photon-mode)
+[photon forward](/reference/light/photon-forward),
+[photon flip](/reference/light/photon-flip),
+[photon mode](/reference/light/set-photon-mode),
+[rgb](/reference/light/rgb)
 
 ```package
 circuit-playground


### PR DESCRIPTION
RE: #708 

Add notes about hue not being an RGB value. Also, it looks like `red` lost its position as `255` and is now `128`.

Comment:

Many of these light docs are duped in common-packages. Any thought about deleting them here and changing the help paths in _ns.ts_ to "light/neopixelstrip/xxx-xxxxxx"?
