### PR TITLE
removing light.createNeoPixel rewrite rule

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -189,7 +189,6 @@
                         "light\\.pixels\\.(__)?showAnimationFrame": "light.showAnimation",
                         "light\\.pixels\\.(__)?clear": "light.clear",
                         "light\\.pixels\\.(__)?stopAllAnimations": "light.stopAllAnimations",
-                        "light\\.createNeoPixelStrip": "light.createStrip",
                         "light\\.pixels\\.__setPixelWhiteLED": "light.pixels.setPixelWhiteLED",
                         "light\\.pixels\\.__show": "light.pixels.show",
                         "light\\.pixels\\.__length": "light.pixels.length",


### PR DESCRIPTION
This rewrite rules is dangerous as it potentially creates stack overflows if applied on the bundled packages.

In particular, this call https://github.com/Microsoft/pxt-adafruit/blob/master/libs/light/create.ts#L21 might get rewritten and SO. In general, upgrades should be applicable to any version harmlessly.