### PR TITLE
Remove the second 'About' summary link

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,7 +16,6 @@
     * [Wearable NeoPixels](/projects/wearable-neopixels)
     * [Fabric Friend](/projects/fabric-friend)
 
-
 ## Examples #examples
 
 * [Examples](/examples)
@@ -51,7 +50,3 @@
 * [Hardware](/device)
     * [Simulator](/device/simulator)
     * [USB](/device/usb)
-
-## About #about
-
-* [About](/about)


### PR DESCRIPTION
RE: #785 

There are two SUMMARY links: one coming from pxt's SUMMARY at the top and one from pxt-adafruit's extended SUMMARY at the bottom. We'll remove the latter link.

This will at least set the pathway to:

![image](https://user-images.githubusercontent.com/27789908/42541762-a5f2e8d0-8458-11e8-884c-a5754c829c1b.png)

instead of this as before:

![image](https://user-images.githubusercontent.com/27789908/42541702-61dfe22e-8458-11e8-88a2-655940aed21d.png)

There still is some "bug" in parsing SUMMARY items without a heading entry (see **About** vs. **Blocks**):

```
# Summary

* [About](/about)
* [FAQ](/faq)

## Blocks #blocks

* [Blocks](/blocks)
    * [On Start](/blocks/on-start)
    * [Loops](/blocks/loops)
        * [repeat](/blocks/loops/repeat)
        * [for](/blocks/loops/for)
        * [while](/blocks/loops/wh
```

I think the fix for this is to make a pseudo-heading called **toplevel** which is special cased when the left nav is built where the heading is not rendered but the pathway is formed correctly. This will let targets override those top links also.


```
# Summary

## Toplevel #toplevel

* [About](/about)
* [FAQ](/faq)

## Blocks #blocks

* [Blocks](/blocks)
    * [On Start](/blocks/on-start)
    * [Loops](/blocks/loops)
        * [repeat](/blocks/loops/repeat)
        * [for](/blocks/loops/for)
        * [while](/blocks/loops/wh
```