### PR TITLE
Bump codal, pxt, pxt-core and enable docker build where available

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@types/node": "8.0.53"
   },
   "dependencies": {
-    "pxt-common-packages": "0.23.49",
-    "pxt-core": "3.22.5"
+    "pxt-common-packages": "0.23.51",
+    "pxt-core": "3.22.9"
   },
   "scripts": {
     "serve": "node node_modules/pxt-core/built/pxt.js serve",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -255,7 +255,7 @@
         "codalTarget": {
             "name": "codal-circuit-playground",
             "url": "https://github.com/lancaster-university/codal-circuit-playground",
-            "branch": "v1.4.4",
+            "branch": "v1.5.0",
             "type": "git"
         },
         "codalBinary": "CIRCUIT_PLAYGROUND",
@@ -268,7 +268,8 @@
         },
         "githubCorePackage": "lancaster-university/codal",
         "gittag": "v0.4.0",
-        "serviceId": "codal2cp"
+        "serviceId": "codal2cp",
+        "dockerImage": "pext/yotta:latest"
     },
     "appTheme": {
         "accentColor": "#0089BF",


### PR DESCRIPTION
This pulls in:
* https://github.com/Microsoft/pxt-common-packages/pull/370
* https://github.com/Microsoft/pxt-common-packages/pull/390

and bumps codal to latest (with some renames)