### PR TITLE
Only create neopixel strip object when actually used

### DIFF
--- a/libs/circuit-playground/ns.ts
+++ b/libs/circuit-playground/ns.ts
@@ -59,7 +59,7 @@ enum LightAnimation {
 //% groups='["other", "Color", "Photon", "More"]'
 namespace light {
 
-    //%
+    //% whenUsed
     export const pixels = light.createStrip(defaultPin(), 10);
 
     /**


### PR DESCRIPTION
This keeps the generated binary cleaner