### PR TITLE
Showing default values

### DIFF
--- a/libs/light/create.ts
+++ b/libs/light/create.ts
@@ -7,7 +7,7 @@ namespace light {
      * @param numleds number of leds in the strip, eg: 30
      * @param mode the light encoding mode for different LED strips, eg: NeoPixelMode.RGB_GRB
      */
-    //% blockId="neopixel_create_strip" block="create strip||on %pin with %numleds pixels"
+    //% blockId="neopixel_create_strip" block="create strip on %pin with %numleds pixels"
     //% help="light/create-strip"
     //% trackArgs=0,2
     //% parts="neopixel"


### PR DESCRIPTION
Showing the default values for CreateSprite. 
Fixes https://github.com/Microsoft/pxt-adafruit/issues/834
