### PR TITLE
disable neopixel over SPI DMA

### DIFF
--- a/libs/circuit-playground/pxt.json
+++ b/libs/circuit-playground/pxt.json
@@ -24,5 +24,10 @@
         "microphone": "file:../microphone",
         "touch": "file:../touch"
     },
-    "public": true
+    "public": true,
+    "yotta": {
+        "config": {
+            "NEOPIXEL_SPI": 0
+        }
+    }
 }


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt-adafruit/issues/924 . Neopixel pin is on same sercom as I2c, which is used by crickit.
Tested on sim/hardware as OK.
```
forever(function () {
    crickit.servo1.setAngle(0)
    pause(1000)
    crickit.servo1.setAngle(180)
    pause(1000)
})
forever(function () {
    light.showAnimation(light.rainbowAnimation, 500)
})
```