### PR TITLE
Moving simscreenshot and simgif to experiment

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -367,13 +367,13 @@
         "disableBlockIcons": true,
         "scriptManager": true,
         "baseTheme": "dark",
-        "simScreenshot": true,
-        "simGif": true,
         "simGifTransparent": "rgba(0,0,0,0)",
         "experiments": [
             "autoWebUSBDownload",
             "debugger",
-            "qrCode"
+            "qrCode",
+            "simScreenshot",
+            "simGif"
         ],
         "socialOptions": {
             "twitterHandle": "adafruit",


### PR DESCRIPTION
They are not very useful in adafruit and take considerable space in smaller screens by even hiding the publish button. 

They make sense in arcade. 