### PR TITLE
Enable HF2 HID

### DIFF
--- a/libs/circuit-playground/pxt.json
+++ b/libs/circuit-playground/pxt.json
@@ -29,6 +29,7 @@
     },
     "yotta": {
         "config": {
+            "HF2_HID": 1,
             "PXT_SUPPORT_LIS3DH": 1
         }
     },


### PR DESCRIPTION
Depends on https://github.com/Microsoft/pxt-common-packages/pull/800 but can be merged without it