### PR TITLE
Update tutorials for melody play

### DIFF
--- a/docs/projects/magic-wand/code.md
+++ b/docs/projects/magic-wand/code.md
@@ -16,7 +16,7 @@ Use the on shake event to play a sound and animation when we shake the magic wan
 
 ```cards
 light.showAnimation(light.rainbowAnimation, 500)
-music.playSound(music.sounds(Sounds.MagicWand))
+music.magicWand.play()
 input.onGesture(Gesture.Shake, () => {
 })
 ```
@@ -74,7 +74,7 @@ forever(() => {
     light.showAnimation(light.rainbowAnimation, 500)
 })
 input.onGesture(Gesture.Shake, () => {
-    music.playSound(music.sounds(Sounds.MagicWand))
+    music.magicWand.play()
     light.showAnimation(light.sparkleAnimation, 1500)
 })
 ```

--- a/docs/projects/musical-cloud/code.md
+++ b/docs/projects/musical-cloud/code.md
@@ -114,7 +114,7 @@ Here are all the notes and beats for the song:
 
 Now, to play the song, you have to create a new melody. To do this, you have to switch from **Blocks** to **JavaScript**. So, click on the **JavaScript** tab to go to the JavaScript editor.
 
-Below the last line of code, type ``let song = new music.Melody(twinkle)``. This makes a new ``||music:Melody||`` _object_ which we'll play the song from. So, add on more line of code at the end that says ``song.play()``.
+Below the last line of code, type ``let song = new music.Melody(twinkle)``. This makes a new ``||music:Melody||`` _object_ which we'll play the song from. So, add one more line of code at the end that says ``song.play()``.
 
 ```typescript
 forever(function () {

--- a/docs/projects/musical-cloud/code.md
+++ b/docs/projects/musical-cloud/code.md
@@ -49,7 +49,7 @@ forever(function () {
 })
 ```
 
-## Step 4: Music
+## Step 4: Create the song
 
 From ``||music:MUSIC||``, get a ``||music:set volume||`` and place at the bottom of ``||loops: on start||``. Type in ``155`` for the volume level.
 
@@ -63,8 +63,6 @@ music.setVolume(155)
 
 Go to ``||variables:VARIABLES||`` and click ``Make a Variable...``. Name your new variable ``twinkle``. Pull out the ``||variables:set twinkle to||`` and place it at the bottom of ``||loops:on start||``. Click **ADVANCED** and in ``||text:TEXT||``, get the ``""`` string block and place it in the ``||variables:set twinkle to||``.
 
-In ``||music:MUSIC||``, drag out ``||music:play sound power up||`` and put it after ``||variables:set twinkle to||``. Now, drag a ``||variables:twinkle||`` variable from ``||variables:VARIABLES||`` into the ``||music:play sound||`` where it says ``power up``. 
-
 ```blocks
 let strip: light.NeoPixelStrip = null
 let twinkle = ""
@@ -73,7 +71,6 @@ strip.setAll(0x007fff)
 strip.setBrightness(200)
 music.setVolume(155)
 twinkle = ""
-music.playSound(twinkle)
 ```
 
 In the blank string  `""` for ``||variables:twinkle||``, type in the notes, rests, and beats of the _Twinkle Twinkle Little Star_ song. 
@@ -82,21 +79,18 @@ The way to do this is to type in the note first, then the octave (in this case, 
 
 ```block
 let twinkle = "c4:2"
-music.playSound(twinkle)
 ```
 
 After you type in one note, you can add a rest before another note plays. Type in `r:2` after your first note if you want a rest for 2 beats before the next note, like this:
 
 ```block
 let twinkle = "c4:2 r:2 c4:2"
-music.playSound(twinkle)
 ```
 
 Keep typing in the notes one by one, with the rests. Experiment with the rests and beats until you get the perfect song! You don't have to use rests but they might make your song sound better. The first line of the song without any rests is this:
 
 ```block
-let twinkle = "c4:1 c4:1 g4:1 g4:1 a4:1 a4:1 g4:1"
-music.playSound(twinkle)
+let twinkle = "c4:1 c4:1 g4:1 g4:1 a4:1 a4:1 g4:2"
 ```
 
 Here are all the notes and beats for the song: 
@@ -115,6 +109,30 @@ Here are all the notes and beats for the song:
 | `c4:1 c4:1` | | `g4:1 g4:1` | | `a4:1 a4:1` | | `g4:2` |
 | **HOW I** | | **WONDER** | | **WHAT YOU** | | **ARE** |
 | `f4:1 f4:1` | | `e4:1 e4:1` | | `d4:1 d4:1` | | `c4:2` |
+
+## Step 5: Play Music
+
+Now, to play the song, you have to create a new melody. To do this, you have to switch from **Blocks** to **JavaScript**. So, click on the **JavaScript** tab to go to the JavaScript editor.
+
+Below the last line of code, type ``let song = new music.Melody(twinkle)``. This makes a new ``||music:Melody||`` _object_ which we'll play the song from. So, add on more line of code at the end that says ``song.play()``.
+
+```typescript
+forever(function () {
+    light.showRing(
+    `blue blue blue blue blue blue blue blue blue blue`
+    )
+    light.setBrightness(200)
+})
+let strip: light.NeoPixelStrip = null
+let twinkle = ""
+strip = light.createStrip(pins.A1, 30)
+strip.setAll(0x007fff)
+strip.setBrightness(200)
+music.setVolume(155)
+twinkle = "c4:1 c4:1 g4:1 g4:1 a4:1 a4:1 g4:2"
+let song = new music.Melody(twinkle)
+song.play()
+```
 
 ## Complete
 

--- a/docs/tutorials/magic-wand.md
+++ b/docs/tutorials/magic-wand.md
@@ -7,7 +7,7 @@ Welcome, let's get started by making something magical! Start by placing a ``||l
 ![rainbow toolbox](/static/cp/tutorials/getting-started/rainbow-toolbox.gif)
 
 ```filterblocks
-forever(() => {
+forever(function() {
     light.showAnimation(light.rainbowAnimation, 500)
 })
 ```
@@ -20,10 +20,10 @@ Click the **Hint** button if you need help!
 ![onshake toolbox](/static/cp/tutorials/getting-started/onshake-toolbox.gif)
 
 ```filterblocks
-forever(() => {
+forever(function() {
     light.showAnimation(light.rainbowAnimation, 500)
 })
-input.onGesture(Gesture.Shake, () => {
+input.onGesture(Gesture.Shake, function() {
 
 })
 ```
@@ -37,10 +37,10 @@ Now, every time you shake the @boardname@, a sparkle animation will play. Pretty
 ![sparkle toolbox](/static/cp/tutorials/getting-started/sparkle-toolbox.gif)
 
 ```filterblocks
-forever(() => {
+forever(function() {
     light.showAnimation(light.rainbowAnimation, 500)
 })
-input.onGesture(Gesture.Shake, () => {
+input.onGesture(Gesture.Shake, function() {
     light.showAnimation(light.sparkleAnimation, 1000)
 })
 ```
@@ -52,27 +52,27 @@ Hey, let's make it play a wand sound whenever we shake the board. From the ``Mus
 ![magic-wand toolbox](/static/cp/tutorials/getting-started/wandsound-toolbox.gif)
 
 ```filterblocks
-forever(() => {
+forever(function() {
     light.showAnimation(light.rainbowAnimation, 500)
 })
-input.onGesture(Gesture.Shake, () => {
+input.onGesture(Gesture.Shake, function() {
     light.stopAllAnimations()
-    music.playSound(music.sounds(Sounds.PowerUp))
+    music.baDing.play()
     light.showAnimation(light.sparkleAnimation, 1000)
 })
 ```
 
 ## Step 5 @nohint
 
-Change the sound effect to ``Magic Wand``. Do this by selecting the list of sounds, then pick the one you want, ``Magic Wand``.
+Change the sound effect to ``Magic Wand``. Do this by selecting the list of sounds, then pick the one you want, ``magic wand``.
 
 ```filterblocks
-forever(() => {
+forever(function() {
     light.showAnimation(light.rainbowAnimation, 500)
 })
-input.onGesture(Gesture.Shake, () => {
+input.onGesture(Gesture.Shake, function() {
     light.stopAllAnimations()
-    music.playSound(music.sounds(Sounds.PowerUp))
+    music.magicWand.play()
     light.showAnimation(light.sparkleAnimation, 1000)
 })
 ```

--- a/docs/tutorials/siren.md
+++ b/docs/tutorials/siren.md
@@ -62,7 +62,7 @@ Hey, let's add some sound! From the ``||music:MUSIC||`` drawer, drag out a ``||m
 
 ```blocks
 input.onGesture(Gesture.Shake, function () {
-    music.playSound(music.sounds(Sounds.PowerUp))
+    music.baDing.play()
     for (let i = 0; i < 4; i++) {
         light.showRing(
         `blue blue blue blue blue blue blue blue blue blue`
@@ -80,7 +80,7 @@ Click on the part of the ``||music:play sound||`` block that shows the name of t
 
 ```blocks
 input.onGesture(Gesture.Shake, function () {
-    music.playSound(music.sounds(Sounds.Siren))
+    music.siren.play()
     for (let i = 0; i < 4; i++) {
         light.showRing(
         `blue blue blue blue blue blue blue blue blue blue`


### PR DESCRIPTION
Change tutorials with ``playSound()`` to ``play()`` for fixed melody instances.

Fixes #960 
Fixes #961
Fixes #985 