### PR TITLE
Add check for dot star leds before making APA102 strip

### DIFF
--- a/libs/light/onboardstrip.ts
+++ b/libs/light/onboardstrip.ts
@@ -12,10 +12,10 @@ namespace light {
 
         const data = pins.pinByCfg(DAL.CFG_PIN_DOTSTAR_DATA);
         const clk = pins.pinByCfg(DAL.CFG_PIN_DOTSTAR_CLOCK);
-        const dsnum = control.getConfigValue(DAL.CFG_NUM_DOTSTARS, 1);
+        const dsnum = control.getConfigValue(DAL.CFG_NUM_DOTSTARS, 0);
         const neo = pins.pinByCfg(DAL.CFG_PIN_NEOPIXEL);
         const neonum = control.getConfigValue(DAL.CFG_NUM_NEOPIXELS, 1);
-        if (data && clk) {
+        if (data && clk && dsnum > 0) {
             _onboardStrip = light.createAPA102Strip(data, clk, dsnum);
             _onboardStrip.setBrightness(96);
         } else if (neo) {

--- a/libs/light/onboardstrip.ts
+++ b/libs/light/onboardstrip.ts
@@ -14,7 +14,7 @@ namespace light {
         const clk = pins.pinByCfg(DAL.CFG_PIN_DOTSTAR_CLOCK);
         const dsnum = control.getConfigValue(DAL.CFG_NUM_DOTSTARS, 0);
         const neo = pins.pinByCfg(DAL.CFG_PIN_NEOPIXEL);
-        const neonum = control.getConfigValue(DAL.CFG_NUM_NEOPIXELS, 1);
+        const neonum = control.getConfigValue(DAL.CFG_NUM_NEOPIXELS, 0);
         if (data && clk && dsnum > 0) {
             _onboardStrip = light.createAPA102Strip(data, clk, dsnum);
             _onboardStrip.setBrightness(96);


### PR DESCRIPTION
Adds a check to make sure there actually is any dot star leds before making the onboard strip an apa102 strip.

Fixes Microsoft/pxt-adafruit#1051