### PR TITLE
override to move gradient to light -> neopixel category

### DIFF
--- a/libs/light/neopixeloverrides.ts
+++ b/libs/light/neopixeloverrides.ts
@@ -8,6 +8,10 @@ declare namespace light {
 
         //% advanced=false
         //% subcategory="NeoPixel"
+        setGradient(startColor: number, endColor: number): void;
+
+        //% advanced=false
+        //% subcategory="NeoPixel"
         graph(value: number, high: number): void;
 
         //% advanced=false

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/web-bluetooth": "0.0.4"
   },
   "dependencies": {
-    "pxt-common-packages": "6.14.13",
+    "pxt-common-packages": "6.14.14",
     "pxt-core": "5.20.3"
   },
   "scripts": {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-adafruit/issues/1088

~requires https://github.com/microsoft/pxt-common-packages/pull/933, which probably also needs to go to a stable branch?~ added common packages version bump to include this