### PR TITLE
Include Flipgrid links in CN projects

### DIFF
--- a/docs/projects/cartoon-network/bmo-music-box.md
+++ b/docs/projects/cartoon-network/bmo-music-box.md
@@ -11,22 +11,13 @@ BMO is Finn and Jake's loyal, protective and helpful friend, who also happens to
 https://youtu.be/M1RwRYzcDYQ 
 <br/>
 
-### ~ hint
-
-#### Flipgrid topic
-
-This project is also a Flipgrid topic:
-
-https://flipgrid.com/bde07799
-
-### ~
-
 ## Prepare
 
 ### This project
 
 **Level**: Medium<br/>
-**Duration**: 60 minutes
+**Duration**: 60 minutes<br/>
+**Flipgrid**: https://flipgrid.com/bde07799
 
 ### Materials
 

--- a/docs/projects/cartoon-network/bmo-music-box.md
+++ b/docs/projects/cartoon-network/bmo-music-box.md
@@ -11,6 +11,16 @@ BMO is Finn and Jake's loyal, protective and helpful friend, who also happens to
 https://youtu.be/M1RwRYzcDYQ 
 <br/>
 
+### ~ hint
+
+#### Flipgrid topic
+
+This project is also a Flipgrid topic:
+
+https://flipgrid.com/bde07799
+
+### ~
+
 ## Prepare
 
 ### This project

--- a/docs/projects/cartoon-network/crown.md
+++ b/docs/projects/cartoon-network/crown.md
@@ -10,6 +10,16 @@ Ice King is a menacing but largely misunderstood ice wizard whose crown is the s
 
 ![Completed crown project](/static/cp/projects/cartoon-network/crown/crown-project.gif)
 
+### ~ hint
+
+#### Flipgrid topic
+
+This project is also a Flipgrid topic:
+
+https://flipgrid.com/3c1dffc8
+
+### ~
+
 ## Prepare
 
 ### This project

--- a/docs/projects/cartoon-network/crown.md
+++ b/docs/projects/cartoon-network/crown.md
@@ -10,22 +10,13 @@ Ice King is a menacing but largely misunderstood ice wizard whose crown is the s
 
 ![Completed crown project](/static/cp/projects/cartoon-network/crown/crown-project.gif)
 
-### ~ hint
-
-#### Flipgrid topic
-
-This project is also a Flipgrid topic:
-
-https://flipgrid.com/3c1dffc8
-
-### ~
-
 ## Prepare
 
 ### This project
 
 **Level**: Easy<br/>
-**Duration**: 30 minutes
+**Duration**: 30 minutes<br/>
+**Flipgrid**: https://flipgrid.com/3c1dffc8
 
 ### Materials
 

--- a/docs/projects/cartoon-network/cup-lamp.md
+++ b/docs/projects/cartoon-network/cup-lamp.md
@@ -8,22 +8,13 @@ Finn the Human is a fiery little kid with strong morals who lives in the Land of
 
 ![Completed Cup Lamp project](/static/cp/projects/cartoon-network/cup-lamp/cup-lamp-project.gif)
 
-### ~ hint
-
-#### Flipgrid topic
-
-This project is also a Flipgrid topic:
-
-https://flipgrid.com/51b13636
-
-### ~
-
 ## Prepare
 
 ### This project
 
 **Level**: Medium<br/>
-**Duration**: 60 minutes
+**Duration**: 60 minutes<br/>
+**Flipgrid**: https://flipgrid.com/51b13636
 
 ### Materials
 

--- a/docs/projects/cartoon-network/cup-lamp.md
+++ b/docs/projects/cartoon-network/cup-lamp.md
@@ -8,6 +8,16 @@ Finn the Human is a fiery little kid with strong morals who lives in the Land of
 
 ![Completed Cup Lamp project](/static/cp/projects/cartoon-network/cup-lamp/cup-lamp-project.gif)
 
+### ~ hint
+
+#### Flipgrid topic
+
+This project is also a Flipgrid topic:
+
+https://flipgrid.com/51b13636
+
+### ~
+
 ## Prepare
 
 ### This project

--- a/docs/projects/cartoon-network/darwin-goldfish.md
+++ b/docs/projects/cartoon-network/darwin-goldfish.md
@@ -8,6 +8,16 @@ Darwin used to be the family pet until he sprouted legs and became one of the Wa
 
 ![Completed Darwin make](/static/cp/projects/cartoon-network/darwin-goldfish/darwin-project.gif)
 
+### ~ hint
+
+#### Flipgrid topic
+
+This project is also a Flipgrid topic:
+
+https://flipgrid.com/740cd96d
+
+### ~
+
 ## Prepare
 
 ### This project

--- a/docs/projects/cartoon-network/darwin-goldfish.md
+++ b/docs/projects/cartoon-network/darwin-goldfish.md
@@ -8,22 +8,13 @@ Darwin used to be the family pet until he sprouted legs and became one of the Wa
 
 ![Completed Darwin make](/static/cp/projects/cartoon-network/darwin-goldfish/darwin-project.gif)
 
-### ~ hint
-
-#### Flipgrid topic
-
-This project is also a Flipgrid topic:
-
-https://flipgrid.com/740cd96d
-
-### ~
-
 ## Prepare
 
 ### This project
 
 **Level**: Easy<br/>
-**Duration**: 30 minutes
+**Duration**: 30 minutes<br/>
+**Flipgrid**: https://flipgrid.com/740cd96d
 
 ### Materials
 

--- a/docs/projects/cartoon-network/enchiridion.md
+++ b/docs/projects/cartoon-network/enchiridion.md
@@ -11,22 +11,13 @@ The Enchiridion (which translates to "The Handbook" or "The Manual") is an ancie
 https://youtu.be/PezmgdB1kOE 
 <br/>
 
-### ~ hint
-
-#### Flipgrid topic
-
-This project is also a Flipgrid topic:
-
-https://flipgrid.com/3a051ac5
-
-### ~
-
 ## Prepare
 
 ### This project
 
 **Level**: Medium<br/>
-**Duration**: 60 minutes
+**Duration**: 60 minutes<br/>
+**Flipgrid**: https://flipgrid.com/3a051ac5
 
 ### Materials
 

--- a/docs/projects/cartoon-network/enchiridion.md
+++ b/docs/projects/cartoon-network/enchiridion.md
@@ -11,6 +11,16 @@ The Enchiridion (which translates to "The Handbook" or "The Manual") is an ancie
 https://youtu.be/PezmgdB1kOE 
 <br/>
 
+### ~ hint
+
+#### Flipgrid topic
+
+This project is also a Flipgrid topic:
+
+https://flipgrid.com/3a051ac5
+
+### ~
+
 ## Prepare
 
 ### This project

--- a/docs/projects/cartoon-network/jake-hotdog.md
+++ b/docs/projects/cartoon-network/jake-hotdog.md
@@ -11,6 +11,16 @@ Jake is a shape-shifting dog who is Finn's best friend and adoptive brother in A
 https://youtu.be/s9QNnYTeSVI
 <br/>
 
+### ~ hint
+
+#### Flipgrid topic
+
+This project is also a Flipgrid topic:
+
+https://flipgrid.com/665fd293
+
+### ~
+
 ## Prepare
 
 ### This project

--- a/docs/projects/cartoon-network/jake-hotdog.md
+++ b/docs/projects/cartoon-network/jake-hotdog.md
@@ -11,22 +11,13 @@ Jake is a shape-shifting dog who is Finn's best friend and adoptive brother in A
 https://youtu.be/s9QNnYTeSVI
 <br/>
 
-### ~ hint
-
-#### Flipgrid topic
-
-This project is also a Flipgrid topic:
-
-https://flipgrid.com/665fd293
-
-### ~
-
 ## Prepare
 
 ### This project
 
 **Level**: Medium<br/>
-**Duration**: 60 minutes
+**Duration**: 60 minutes<br/>
+**Flipgrid**: https://flipgrid.com/665fd293
 
 ### Materials
 

--- a/docs/projects/cartoon-network/room-sign.md
+++ b/docs/projects/cartoon-network/room-sign.md
@@ -8,6 +8,16 @@ Make sure everyone knows whose room it is, even at night with this Amazing World
 
 ![Completed Room Sign project](/static/cp/projects/cartoon-network/room-sign/room-sign-project.gif)
 
+### ~ hint
+
+#### Flipgrid topic
+
+This project is also a Flipgrid topic:
+
+https://flipgrid.com/bf121bf3
+
+### ~
+
 ## Prepare
 
 ### This project

--- a/docs/projects/cartoon-network/room-sign.md
+++ b/docs/projects/cartoon-network/room-sign.md
@@ -8,22 +8,13 @@ Make sure everyone knows whose room it is, even at night with this Amazing World
 
 ![Completed Room Sign project](/static/cp/projects/cartoon-network/room-sign/room-sign-project.gif)
 
-### ~ hint
-
-#### Flipgrid topic
-
-This project is also a Flipgrid topic:
-
-https://flipgrid.com/bf121bf3
-
-### ~
-
 ## Prepare
 
 ### This project
 
 **Level**: Easy<br/>
-**Duration**: 30 minutes
+**Duration**: 30 minutes<br/>
+**Flipgrid**: https://flipgrid.com/bf121bf3
 
 ### Materials
 


### PR DESCRIPTION
Add the flipgrid topic links to the Prepare section of the CN projects.

Closes #1157