### PR TITLE
enable japanese

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -362,7 +362,8 @@
         "selectLanguage": true,
         "availableLocales": [
             "en",
-            "de"
+            "de",
+            "ja"
         ],
         "simAnimationEnter": "roll in",
         "simAnimationExit": "roll out",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -11,7 +11,9 @@
         ]
     },
     "languages": [
-        "en"
+        "en",
+        "de",
+        "ja"        
     ],
     "galleries": {
         "Tutorials": "tutorials",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -4,8 +4,7 @@
             "Microsoft",
             "Adafruit"
         ],
-        "approvedRepos": [
-        ],
+        "approvedRepos": [],
         "preferredRepos": [
             "Adafruit/pxt-crickit"
         ]
@@ -13,7 +12,7 @@
     "languages": [
         "en",
         "de",
-        "ja"        
+        "ja"
     ],
     "galleries": {
         "Tutorials": "tutorials",


### PR DESCRIPTION
Crowdin users have fully translated all the blocks.

we need targetconfig.json because the released adafruit version still uses it
