### PR TITLE
include dal file

### DIFF
--- a/sim/dalboard.ts
+++ b/sim/dalboard.ts
@@ -1,6 +1,7 @@
 /// <reference path="../node_modules/pxt-core/built/pxtsim.d.ts"/>
 /// <reference path="../node_modules/pxt-core/localtypings/pxtarget.d.ts"/>
 /// <reference path="../built/common-sim.d.ts"/>
+/// <reference path="../libs/core/dal.d.ts"/>
 
 namespace pxsim {
     export module CPlayPinName {


### PR DESCRIPTION
For some reason, the dal.d.ts file is not referenced in the simulator anymore.