### PR TITLE
Update the 'Counter' example

### DIFF
--- a/docs/examples/counter.md
+++ b/docs/examples/counter.md
@@ -1,6 +1,8 @@
 # Light counter
 
-A counter that uses the LED lights.
+A 2-digit counter (values are 0 - 99) that uses the LED lights. The LEDs on the ring represent digits `0` to `9` in the counterclockwise direction. Press `A` to count up or press `B` to count down.
+
+A **red** LED shows the value of the _ones_ digit and a **green** LED shows the value of the _tens_ digit. When both the ones digit and the tens digit are the same, a single **blue** LED is shown.
 
 ```blocks
 let isTen = false
@@ -15,24 +17,25 @@ function render() {
     light.clear()
     for (let i = 0; i <= 9; i++) {
         isDigit = i == digits
-        isTen = i + 1 == tens
+        isTen = (i == tens) && (i > 0)
         if (isTen && isDigit) {
-            light.setPixelColor(i, 0xa033e5)
-        } else if (isTen) {
             light.setPixelColor(i, 0x0000ff)
+        } else if (isTen) {
+            light.setPixelColor(i, 0x00ff00)
         } else if (isDigit) {
             light.setPixelColor(i, 0xff0000)
         }
     }
 }
 input.buttonB.onEvent(ButtonEvent.Click, function () {
-    count += 1
+    if (count < 99) {
+        count += 1
+    }
     render()
 })
 input.buttonA.onEvent(ButtonEvent.Click, function () {
-    count += -1
-    if (count < 0) {
-        count = 0
+    if (count > 0) {
+        count += -1
     }
     render()
 })


### PR DESCRIPTION
Modify the example to count with the LEDs in a `0` - `9` fashion and show the tens digit only when it's > `0`. Also, limit the counter range from `0` to `99`.

The tens digit discriminator uses a simple check of `i > 0` rather than adding the `cntGT9` variable as suggested in #1202. Otherwise, the rest of the revised example is used.

Fixes #1202

**NOTE:** Adafruit builds are failing due to an NPM install problem.